### PR TITLE
fix: 인테리어 댓글 기능, 가구 목록 기능 수정

### DIFF
--- a/allo/urls.py
+++ b/allo/urls.py
@@ -26,7 +26,7 @@ urlpatterns = [
     path('recipe/', include('recipe.urls')),
     path('recycle/', include('recycle.urls')),
     path('', include('users.urls')),
-]
+]+ static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)
 
 if settings.DEBUG:
     urlpatterns += static(settings.STATIC_URL, document_root=settings.STATIC_ROOT)

--- a/community/forms.py
+++ b/community/forms.py
@@ -9,7 +9,7 @@ class PostForm(forms.ModelForm):
 class MessageForm(forms.ModelForm):
     class Meta:
         model = Message
-        fields = ['content']
+        fields = ['content','image']
 
 class CommentForm(forms.ModelForm):
     class Meta:

--- a/community/models.py
+++ b/community/models.py
@@ -34,6 +34,7 @@ class Message(models.Model):
     receiver = models.ForeignKey(settings.AUTH_USER_MODEL, on_delete=models.CASCADE, related_name='received_messages')
     content = models.TextField()
     timestamp = models.DateTimeField(auto_now_add=True)
+    image = models.ImageField(upload_to='messages/', null=True, blank=True)
 
     def __str__(self):
         return f'{self.sender.username}: {self.content}'

--- a/interior/urls.py
+++ b/interior/urls.py
@@ -20,7 +20,7 @@ urlpatterns = [
     path('send_friend_request/<str:username>/', community_views.send_friend_request, name='send_friend_request'),
     path('accept_friend_request/<int:request_id>/', community_views.accept_friend_request, name='accept_friend_request'),
     path('decline_friend_request/<int:request_id>/', community_views.decline_friend_request, name='decline_friend_request'),
-]
+]+ static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)
 
 if settings.DEBUG:
     urlpatterns += static(settings.STATIC_URL, document_root=settings.STATIC_ROOT)

--- a/interior/views.py
+++ b/interior/views.py
@@ -17,6 +17,7 @@ def interior_list(request):
         posts = InteriorPost.objects.filter(category=category).order_by('-created_at')
     return render(request, 'interior/interior_list.html', {'posts': posts, 'category': category})
 
+
 @login_required
 def interior_detail(request, pk):
     post = get_object_or_404(InteriorPost, pk=pk)
@@ -33,8 +34,10 @@ def interior_detail(request, pk):
         'friends': friends,
         'comments': comments,
         'comment_form': comment_form,
+        'furniture_list': post.furniture_list.split(',') if post.furniture_list else [],  # split the list for display
     }
     return render(request, 'interior/interior_detail.html', context)
+
 
 
 @login_required
@@ -43,7 +46,7 @@ def interior_new(request):
         form = InteriorPostForm(request.POST, request.FILES)
         if form.is_valid():
             post = form.save(commit=False)
-            post.furniture_list = request.POST.get('furniture_list', '')
+            post.furniture_list = request.POST.getlist('furniture_list[]')  # getlist to handle multiple inputs
             post.author = request.user  
             post.save()
             request.user.participation_score += 2
@@ -54,17 +57,26 @@ def interior_new(request):
     
     return render(request, 'interior/interior_form.html', {'form': form})
 
+
 @login_required
 def interior_update(request, pk):
     post = get_object_or_404(InteriorPost, pk=pk)
     if request.method == 'POST':
-        form = InteriorPostForm(request.POST, instance=post)
+        form = InteriorPostForm(request.POST, request.FILES, instance=post)
         if form.is_valid():
-            form.save()
-            return redirect('interior_user:interior_detail',pk=post.pk)
+            post = form.save(commit=False)
+            furniture_list = request.POST.getlist('furniture_list[]')
+            # 빈 값 제거
+            furniture_list = [item for item in furniture_list if item.strip()]
+            post.furniture_list = ','.join(furniture_list)
+            post.save()
+            return redirect('interior_user:interior_detail', pk=post.pk)
     else:
         form = InteriorPostForm(instance=post)
-    return render(request, 'interior/interior_form.html', {'form': form})
+        furniture_list = post.furniture_list.split(',') if post.furniture_list else []
+
+    return render(request, 'interior/interior_form.html', {'form': form, 'furniture_list': furniture_list})
+
 
 @login_required
 def interior_delete(request, pk):

--- a/static/css/interior/interior_detail.css
+++ b/static/css/interior/interior_detail.css
@@ -83,6 +83,28 @@
     margin: 10px auto;
 }
 
+.furniture-list {
+    margin-top: 20px;
+    padding: 10px;
+    border-top: 1px solid #ccc;
+}
+
+.furniture-list h3 {
+    font-size: 1.5em;
+    margin-bottom: 10px;
+}
+
+.furniture-list ul {
+    list-style-type: disc;
+    padding-left: 20px;
+}
+
+.furniture-list li {
+    font-size: 1.2em;
+    margin-bottom: 5px;
+}
+
+
 /* 댓글 */
 .comment-line {
     border-top: 7px solid var(--light--gray--color);

--- a/static/js/interior/interior_create.js
+++ b/static/js/interior/interior_create.js
@@ -54,7 +54,4 @@ document.querySelector('form').addEventListener('submit', function(e) {
         alert('가구 목록은 최소 하나 이상이어야 합니다.');
         return;
     }
-
-    var hiddenInput = document.querySelector('input[name="furniture_list"]');
-    hiddenInput.value = furnitureList.join('\n');
 });

--- a/templates/interior/interior_detail.html
+++ b/templates/interior/interior_detail.html
@@ -59,6 +59,17 @@
 <img src="{{ post.image.url }}" alt="{{ post.title }}" class="interior-detail-img">
 <p class="interior-detail-content">{{ post.content }}</p>
 
+{% if furniture_list %}
+<div class="furniture-list">
+    <h3>가구 목록:</h3>
+    <ul>
+        {% for item in furniture_list %}
+            <li>{{ item }}</li>
+        {% endfor %}
+    </ul>
+</div>
+{% endif %}
+
 <p class="interior-detail-comment-title">{{ comments|length }}개의 댓글이 있습니다.</p>
 <ul id="comment-list">
     {% for comment in comments %}

--- a/templates/interior/interior_form.html
+++ b/templates/interior/interior_form.html
@@ -26,13 +26,22 @@
     <div class="interior-furniture-list-container">
         <h4 class="interior-furniture-list">가구 목록:</h4>
         <div class="furniture-fields-container" id="furniture_fields">
-            <div class="furniture-item">
-                <input type="text" name="furniture_list[]" class="form-control">
-                <button type="button" onclick="removeFurnitureField(this)" class="interior-furniture-remove-btn">삭제</button>
-            </div>
+            {% for item in furniture_list %}
+                <div class="furniture-item">
+                    <input type="text" name="furniture_list[]" class="form-control" value="{{ item }}">
+                    <button type="button" onclick="removeFurnitureField(this)" class="interior-furniture-remove-btn">삭제</button>
+                </div>
+            {% endfor %}
+            {% if not furniture_list %}
+                <div class="furniture-item">
+                    <input type="text" name="furniture_list[]" class="form-control">
+                    <button type="button" onclick="removeFurnitureField(this)" class="interior-furniture-remove-btn">삭제</button>
+                </div>
+            {% endif %}
         </div>
         <button type="button" onclick="addFurnitureField()" class="interior-furniture-add-btn">+가구 추가</button>
-    </div>
+    </div>  
+    
     <button type="submit" class="interior-create-btn">작성하기</button>
     {{ form.furniture_list }}
 </form>


### PR DESCRIPTION
1. 인테리어에 가구 목록을 추가해도 디테일 페이지에 가구 목록이 안뜨고 수정할 때도 가구 목록이 저장이 안되어 있는 문제 해결
2. 수정 버튼을 누르면 가구 목록이 빈칸으로 하나 더 생겨 있는 문제 해결
3. interior앱도 처음 댓글이 작성될 때와 새로고침 후에도 일관된 모양으로 댓글 목록이 유지되게 함